### PR TITLE
Fixed the NtReadVirtualMemory and DllLoadNotification hooks

### DIFF
--- a/cuckoomon.c
+++ b/cuckoomon.c
@@ -646,7 +646,7 @@ void revalidate_all_hooks(void)
 
 PVOID g_dll_notify_cookie;
 
-VOID CALLBACK DllLoadNotification(
+VOID CALLBACK New_DllLoadNotification(
 	_In_     ULONG                       NotificationReason,
 	_In_     const PLDR_DLL_NOTIFICATION_DATA NotificationData,
 	_In_opt_ PVOID                       Context)
@@ -742,9 +742,9 @@ void set_hooks()
 	free(suspended_threads);
 
 	if (pLdrRegisterDllNotification)
-		pLdrRegisterDllNotification(0, &DllLoadNotification, NULL, &g_dll_notify_cookie);
+		pLdrRegisterDllNotification(0, &New_DllLoadNotification, NULL, &g_dll_notify_cookie);
 	else
-		register_dll_notification_manually(&DllLoadNotification);
+		register_dll_notification_manually(&New_DllLoadNotification);
 
 	hook_enable();
 }

--- a/hook_process.c
+++ b/hook_process.c
@@ -542,7 +542,7 @@ HOOKDEF(NTSTATUS, WINAPI, NtReadVirtualMemory,
 
     ret = Old_NtReadVirtualMemory(ProcessHandle, BaseAddress, Buffer, NumberOfBytesToRead, NumberOfBytesRead);
 
-    LOQ_ntstatus("process", "ppB", "ProcessHandle", ProcessHandle, "BaseAddress", BaseAddress, NumberOfBytesToRead, "Size", "Buffer", NumberOfBytesRead, Buffer);
+    LOQ_ntstatus("process", "pphB", "ProcessHandle", ProcessHandle, "BaseAddress", BaseAddress, "Size", NumberOfBytesToRead, "Buffer", NumberOfBytesRead, Buffer);
 
 	return ret;
 }


### PR DESCRIPTION
This pull request aims to fix 2 bugs in the monitoring DLL.

1. The arguments to the logging call in NtReadVirtualMemory are mixed up, which causes any sample to crash the monitoring dll that calls this API:

`LOQ_ntstatus("process", "ppB", "ProcessHandle", ProcessHandle, "BaseAddress", BaseAddress, NumberOfBytesToRead, "Size", "Buffer", NumberOfBytesRead, Buffer);`

The format string is also missing one item, it should be "pphB" instead of "ppB".

2. The first 4 characters of every function name are stripped off in the behavior log (on the web UI), see `&__FUNCTION__[4]` [here](https://github.com/ctxis/capemon/blob/capemon/log.h#L110). This is done in order to be able to display the correct API names, as the hooked functions are named as "New_<apiname>" in the source code (these are automatically generated through the HOOK macro). This functionality causes the DllLoadNotification hook in cuckoomon.c to be displayed as "oadNotification" on the web UI. So this fix simply prepends "New_" to the beginning of the name to ensure proper display on the web UI.

You can test the fix on this malware sample: [010da3a7ba19ee93a32ba488a8081f2b](https://www.virustotal.com/#/file/b17b9abcbeea1aa371bcbb52259e73c0465679a76d36c596df46ccc16660bead/detection)