### PR TITLE
Replaced FindResource with the lower level FindResourceEx, and fixed …

### DIFF
--- a/cuckoomon.c
+++ b/cuckoomon.c
@@ -429,8 +429,10 @@ static hook_t g_hooks[] = {
 	HOOK(user32, SystemParametersInfoW),
 	HOOK(pstorec, PStoreCreateInstance),
 	HOOK(advapi32, SaferIdentifyLevel),
-	HOOK(kernel32, FindResourceA),
-	HOOK(kernel32, FindResourceW),
+
+	// PE resource related functions
+	HOOK(kernel32, FindResourceExA),
+	HOOK(kernel32, FindResourceExW),
 	HOOK(kernel32, LoadResource),
 	HOOK(kernel32, LockResource),
 	HOOK(kernel32, SizeofResource),

--- a/hook_misc.c
+++ b/hook_misc.c
@@ -1147,33 +1147,59 @@ HOOKDEF(int, WINAPI, lstrcmpiA,
     return ret;
 }
 
-HOOKDEF(HRSRC, WINAPI, FindResourceA,
-  HMODULE hModule,
-  LPCSTR lpName,
-  LPCSTR lpType
+HOOKDEF(HRSRC, WINAPI, FindResourceExA,
+    HMODULE hModule,
+    LPCSTR lpType,
+    LPCSTR lpName,
+    WORD wLanguage
 )
 {
-    HRSRC ret = Old_FindResourceA(hModule, lpName, lpType);
+    HRSRC ret = Old_FindResourceExA(hModule, lpType, lpName, wLanguage);
 
-    LOQ_handle("misc", "ps", "Module", hModule, "Name", lpName);
+    char type_id[8];
+    if (IS_INTRESOURCE(lpType)) {
+        snprintf(type_id, sizeof type_id, "#%hu", (WORD)lpType);
+        lpType = type_id;
+    }
+
+    char name_id[8];
+    if (IS_INTRESOURCE(lpName)) {
+        snprintf(name_id, sizeof name_id, "#%hu", (WORD)lpName);
+        lpName = name_id;
+    }
+
+    LOQ_handle("misc", "pssh", "Module", hModule, "Type", lpType, "Name", lpName, "Language", wLanguage);
 
     return ret;
 }
 
- HOOKDEF(HRSRC, WINAPI, FindResourceW,
-  HMODULE hModule,
-  LPCWSTR lpName,
-  LPCWSTR lpType
+HOOKDEF(HRSRC, WINAPI, FindResourceExW,
+    HMODULE hModule,
+    LPCWSTR lpType,
+    LPCWSTR lpName,
+    WORD wLanguage
 )
 {
-    HRSRC ret = Old_FindResourceW(hModule, lpName, lpType);
+    HRSRC ret = Old_FindResourceExW(hModule, lpType, lpName, wLanguage);
 
-    LOQ_handle("misc", "pu", "Module", hModule, "Name", lpName);
+    wchar_t type_id[8];
+    if (IS_INTRESOURCE(lpType)) {
+        swprintf(type_id, sizeof type_id, L"#%hu", (WORD)lpType);
+        lpType = type_id;
+    }
+
+    wchar_t name_id[8];
+    if (IS_INTRESOURCE(lpName)) {
+        swprintf(name_id, sizeof name_id, L"#%hu", (WORD)lpName);
+        lpName = name_id;
+    }
+
+    LOQ_handle("misc", "puuh", "Module", hModule, "Type", lpType, "Name", lpName, "Language", wLanguage);
 
     return ret;
 }
 
- HOOKDEF(HGLOBAL, WINAPI, LoadResource,
+HOOKDEF(HGLOBAL, WINAPI, LoadResource,
   _In_opt_ HMODULE hModule,
   _In_     HRSRC   hResInfo
 )

--- a/hooks.h
+++ b/hooks.h
@@ -2894,16 +2894,18 @@ extern HOOKDEF(int, WINAPI, lstrcmpiA,
   _In_  LPCSTR   lpString2
 );
 
-extern HOOKDEF(HRSRC, WINAPI, FindResourceA,
+extern HOOKDEF(HRSRC, WINAPI, FindResourceExA,
   HMODULE hModule,
+  LPCSTR lpType,
   LPCSTR lpName,
-  LPCSTR lpType
+  WORD wLanguage
 );
 
-extern HOOKDEF(HRSRC, WINAPI, FindResourceW,
+extern HOOKDEF(HRSRC, WINAPI, FindResourceExW,
   HMODULE hModule,
+  LPCWSTR lpType,
   LPCWSTR lpName,
-  LPCWSTR lpType
+  WORD wLanguage
 );
 
 extern HOOKDEF(HGLOBAL, WINAPI, LoadResource,


### PR DESCRIPTION
…handling resource IDs

This commit has 2 goals:
1) Fix the handling of resource name and type IDs, because the current implementation caused crashes when resource names or types were passed as WORD values (created with the MAKEINTRESOURCE macro) as it tried to treat them as a pointer to a string.
2) Replaced the FindResourceA/W hooks with the lower level FindResourceExA/W hooks.

Test case (causing a crash with the old implementation): https://www.virustotal.com/#/file/e7d3181ef643d77bb33fe328d1ea58f512b4f27c8e6ed71935a2e7548f2facc0/