### PR TITLE
 Prevent module reloading/remapping via NtMapViewOfSection

### DIFF
--- a/hook_process.c
+++ b/hook_process.c
@@ -506,6 +506,9 @@ HOOKDEF(NTSTATUS, WINAPI, NtMapViewOfSection,
 			pipe("PROCESS:%d:%d", is_suspended(pid, 0), pid);
 			disable_sleep_skip();
 		}
+		else {
+			prevent_module_reloading(BaseAddress);
+		}
 	}
 	return ret;
 }

--- a/misc.h
+++ b/misc.h
@@ -46,8 +46,10 @@ typedef NTSTATUS(WINAPI *_NtQueryKey)(
 	PULONG  ResultLength);
 typedef NTSTATUS(WINAPI *_NtDelayExecution)(
 	BOOLEAN Alertable,
-	PLARGE_INTEGER Interval
-	);
+	PLARGE_INTEGER Interval);
+typedef NTSTATUS(WINAPI *_NtUnmapViewOfSection)(
+	HANDLE ProcessHandle,
+	PVOID BaseAddress);
 
 typedef struct _LDR_DLL_LOADED_NOTIFICATION_DATA {
 	ULONG Flags;
@@ -200,3 +202,5 @@ wchar_t *ascii_to_unicode_dup(char *str);
 int is_stack_pivoted(void);
 
 LONG WINAPI cuckoomon_exception_handler(__in struct _EXCEPTION_POINTERS *ExceptionInfo);
+
+void prevent_module_reloading(PVOID *BaseAddress);


### PR DESCRIPTION
This prevents samples to load an already loaded module from disk via NtCreateSection followed by NtMapViewOfSection. This is how Osiris samples evade the hooks: https://blog.malwarebytes.com/threat-analysis/2018/08/process-doppelganging-meets-process-hollowing_osiris/

When this happens the following log line is added to the analysis log:
`2018-08-16 01:31:37,453 [root] INFO: Sample tried to reload already loaded module 'C:\Windows\System32\ntdll.dll' from disk, returning original module address instead: 0x77480000`

This allows to see Osiris process-doppelganging behavior without having to patch the samples.

Test sample (from the blog): e7d3181ef643d77bb33fe328d1ea58f512b4f27c8e6ed71935a2e7548f2facc0