### PR TITLE
Fix compatibility problems with Office applications

### DIFF
--- a/misc.c
+++ b/misc.c
@@ -1874,18 +1874,34 @@ BOOLEAN is_address_in_ntdll(ULONG_PTR address)
 void prevent_module_reloading(PVOID *BaseAddress) {
 	// prevent hook evasion via mapping system libraries (e.g. ntdll.dll) from disk
 	// this still won't stop reading the file using NtReadFile and mapping it manually
+	wchar_t *whitelist[] = {
+		L"C:\\Windows\\System32\\ntdll.dll",
+		L"C:\\Windows\\SysWOW64\\ntdll.dll",
+		NULL
+	};
+
+	// get the file path for the mapped section
 	wchar_t *filepath = malloc(MAX_PATH * sizeof(wchar_t));
 	GetMappedFileNameW(GetCurrentProcess(), *BaseAddress, filepath, MAX_PATH);
 
+	// convert device path to an actual path
 	wchar_t *absolutepath = malloc(32768 * sizeof(wchar_t));
 	ensure_absolute_unicode_path(absolutepath, filepath);
 	free(filepath);
 
-	HMODULE address = GetModuleHandleW(absolutepath);
-	if (address != NULL) {
-		pipe("INFO:Sample tried to reload already loaded module '%Z' from disk, returning original module address instead: 0x%x", absolutepath, address);
-		pNtUnmapViewOfSection(GetCurrentProcess(), *BaseAddress);
-		*BaseAddress = (LPVOID)address;
+	// check against the whitelist
+	for (int i = 0; whitelist[i]; i++) {
+		if (!wcsicmp(whitelist[i], absolutepath)) {
+			// is this a loaded module?
+			HMODULE address = GetModuleHandleW(absolutepath);
+			if (address != NULL) {
+				pipe("INFO:Sample tried to reload already loaded module '%Z' from disk, returning original module address instead: 0x%x", absolutepath, address);
+				pNtUnmapViewOfSection(GetCurrentProcess(), *BaseAddress);
+				*BaseAddress = (LPVOID)address;
+			}
+			break;
+		}
 	}
+
 	free(absolutepath);
 }


### PR DESCRIPTION
Apparently the "prevent module reload" feature does not play nicely with Word (and probably with other MS Office applications) and causes a crash which has an adversely effect on installations where malicious documents are analyzed.

This fix is intended to limit the modules that are monitored to a module path whitelist that currently contains ntdll.dll only.