### PR TITLE
Fixed entrypoint comparison

### DIFF
--- a/CAPE/ScyllaHarness.cpp
+++ b/CAPE/ScyllaHarness.cpp
@@ -160,7 +160,7 @@ void ScyllaInit(HANDLE hProcess)
 extern "C" int ScyllaDumpProcess(HANDLE hProcess, DWORD_PTR ModuleBase, DWORD_PTR NewOEP)
 //**************************************************************************************
 {
-	SIZE_T SectionBasedFileSize;
+	SIZE_T SectionBasedSizeOfImage;
 	PeParser * peFile = 0;
 	DWORD_PTR entrypoint = NULL;
 
@@ -177,9 +177,9 @@ extern "C" int ScyllaDumpProcess(HANDLE hProcess, DWORD_PTR ModuleBase, DWORD_PT
         else
             entrypoint = peFile->getEntryPoint();
 
-        SectionBasedFileSize = (SIZE_T)peFile->getSectionHeaderBasedFileSize();
+        SectionBasedSizeOfImage = (SIZE_T)peFile->getSectionHeaderBasedSizeOfImage();
 
-        if ((SIZE_T)entrypoint > SectionBasedFileSize)
+        if ((SIZE_T)entrypoint >= SectionBasedSizeOfImage)
         {
             DoOutputDebugString("DumpProcess: Error - entry point too big: 0x%x, ignoring.\n", entrypoint);
             entrypoint = NULL;


### PR DESCRIPTION
The PE entrypoint is a RVA, so it needs to be compared to the virtual size of the image instead of the physical size of the on-disk PE file.

Due to this bug, CAPE ignores the entrypoint for the sample below, because it thinks that the entrypoint is outside of the file:

https://www.virustotal.com/#/file/7580fd88c504adf06797a4375d7e06917d7d83ea0395d893ee3a0aac2fc4f59c/

Before the fix:
```
2018-10-08 02:52:19,030 [root] DEBUG: DumpProcess: Instantiating PeParser with address: 0x15190000.
2018-10-08 02:52:19,030 [root] DEBUG: DumpProcess: Error - entry point too big: 0x3b1e0, ignoring.
2018-10-08 02:52:19,046 [root] INFO: Added new CAPE file to list with path: C:\mncawkqr\CAPE\2264_208051952849521281102018
2018-10-08 02:52:19,046 [root] DEBUG: DumpProcess: Module image dump success - dump size 0x3b000.
```

After the fix:
```
2018-10-08 03:50:51,983 [root] DEBUG: DumpProcess: Instantiating PeParser with address: 0x15190000.
2018-10-08 03:50:51,983 [root] DEBUG: DumpProcess: Module entry point VA is 0x0003B1E0.
2018-10-08 03:50:52,000 [root] INFO: Added new CAPE file to list with path: C:\knweefp\CAPE\3128_28720670622112081102018
2018-10-08 03:50:52,000 [root] DEBUG: DumpProcess: Module image dump success - dump size 0x3b000.
```