### PR TITLE
Fix for VBCrypter samples that try to "fix" hooks in ntdll.dll

### DIFF
--- a/cuckoomon.c
+++ b/cuckoomon.c
@@ -107,7 +107,7 @@ static hook_t g_hooks[] = {
 	HOOK_SPECIAL(ole32, CoCreateInstanceEx),
 	HOOK_SPECIAL(ole32, CoGetClassObject),
 
-	HOOK_NOTAIL(ntdll, RtlDispatchException, 2),
+	HOOK_SPECIAL(ntdll, RtlDispatchException),
 	HOOK_NOTAIL(ntdll, NtRaiseException, 3),
 
 	// lowest variant of MoveFile()

--- a/hooking_32.c
+++ b/hooking_32.c
@@ -30,7 +30,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "config.h"
 
 // length disassembler engine
-static int lde(void *addr)
+int lde(void *addr)
 {
 	// the length of an instruction is 16 bytes max, but there can also be
 	// 16 instructions of length one, so.. we support "decomposing" 16

--- a/hooks.h
+++ b/hooks.h
@@ -1096,7 +1096,7 @@ extern HOOKDEF(NTSTATUS, WINAPI, DbgUiWaitStateChange,
 	__in_opt PLARGE_INTEGER Timeout
 );
 
-extern HOOKDEF_NOTAIL(WINAPI, RtlDispatchException,
+extern HOOKDEF(BOOLEAN, WINAPI, RtlDispatchException,
 	__in PEXCEPTION_RECORD ExceptionRecord,
 	__in PCONTEXT Context
 );


### PR DESCRIPTION
This commit is intended to provide a medium term fix to VBCrypter (of whatever the name of that packer/crypter is) samples: https://www.virustotal.com/#/file/19138797d550d90cf13197c1405e739abeca79cf9e298b4185084d71e02a5e17/

Root cause analysis:
The sample crashes because it has a piece of code that scans ntdll.dll for hooks/modifications and tries to fix them and remove the hooks by restoring the "correct" syscall number (i.e. writing a "MOV EAX,<syscall_number>" as the first instruction). In the case of Capemon this results in
  1) the hooks not being removed at all, because we do not match their hook patterns,
  2) Win32 native functions that are not hooked are being renumbered using a wrong syscall number (which basically mixes up different native functions, causing crashes later.

This commit contains the following changes:
- Converted the notail hook on RtlDispatchException to a special hook. This is needed because RtlDispatchException can actually return a boolean value (false - raise exception, true - continue execution), and basically the notail hook prevented returning a value from the function.
- When the NtProtectVirtualMemory function is invoked, and we detect that a memory region that belongs to ntdll.dll is going to change it's protection value, we prevent that from happening, and basically keep the memory page read-only. This will raise memory access violation exceptions when the packer tries to "fix" the hooks in ntdll.dll
- A new block of code was added to RtlDispatchException, which handles the case when there is a write operation on a memory page belonging to ntdll.dll. In this case we just skip the instruction, and pretend that the write has happened sucessfully.

A long-term solution could be a new hook type that hijacks SharedUserData!SystemCallStub to hook all the native functions without having to change any of the instructions in the native system functions, (see [1]). The drawback of this is approach is that we need to pay special attention to remain compatible between Windows versions, as the SharedUserData!SystemCallStub format has changed in Windows 8/10 [2]. I didn't have time yet to work in this, but I'm going to jump on it as soon as I have some spare time.

[1] http://uninformed.org/index.cgi?v=3&a=4&p=22
[2] https://www.malwaretech.com/2015/07/windows-10-system-call-stub-changes.html
