### PR TITLE
Fixed RtlDispatchException hook

### DIFF
--- a/hook_process.c
+++ b/hook_process.c
@@ -1004,7 +1004,7 @@ HOOKDEF(BOOLEAN, WINAPI, RtlDispatchException,
 	// flush logs prior to handling of an exception without having to register a vectored exception handler
 	log_flush();
 
-	return FALSE;
+	return Old_RtlDispatchException(ExceptionRecord, Context);
 }
 
 HOOKDEF_NOTAIL(WINAPI, NtRaiseException,


### PR DESCRIPTION
I made a small mistake in https://github.com/ctxis/capemon/pull/11 when converting the RtlDispatchException from a notail hook to a special hook. I realized that notail hooks automatically call the original function at the and of the hook, so this needs to be done manually in the special hook.

This is also intended to fix compatibility with MS Office applications, as they crashed with the previous version of my hook (that failed to call the original RtlDispatchException function).